### PR TITLE
Add basic ray tracing demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,16 @@ pip install numpy matplotlib
 
 ## Usage
 
-Run the script to render the shapes:
+Run the script to render the shapes and trace a few sample rays:
 
 ```bash
 python makeShapes.py
 ```
 
-The script will open a window displaying the constructed geometry.
+On headless systems, you can use the non-interactive backend:
+
+```bash
+MPLBACKEND=Agg python makeShapes.py
+```
+
+The script will open a window (or generate an off‑screen figure) displaying the constructed geometry and ray paths.


### PR DESCRIPTION
## Summary
- add ray tracing utilities for segments and reflection
- plot sample rays through generated concentrator shapes
- document usage and headless execution instructions

## Testing
- `python -m py_compile makeShapes.py`
- `MPLBACKEND=Agg python makeShapes.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy matplotlib` *(fails: Could not find a version that satisfies the requirement numpy)*


------
https://chatgpt.com/codex/tasks/task_e_68a264b7bd20832b9282bb83097ff5d9