### PR TITLE
Add type annotations to cone utilities

### DIFF
--- a/python/ConeProfile.py
+++ b/python/ConeProfile.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python
 import numpy as np
+from typing import Dict, Optional, Sequence
 
-def make_planar(din, dout, angle, width, height):
-  config = {
+def make_planar(
+    din: float,
+    dout: float,
+    angle: float,
+    width: float,
+    height: float,
+) -> Dict[str, object]:
+  config: Dict[str, object] = {
     'name': 'planar',
     'n_walls': 4,
     'din': din,
@@ -23,8 +30,15 @@ def make_planar(din, dout, angle, width, height):
   return config
 
 
-def make_winston(din, dout, crit_angle, width, height, n_points=512):
-  config = {
+def make_winston(
+    din: float,
+    dout: float,
+    crit_angle: float,
+    width: float,
+    height: float,
+    n_points: int = 512,
+) -> Dict[str, object]:
+  config: Dict[str, object] = {
     'name': 'winston',
     'n_walls': 4,
     'din': din,
@@ -66,7 +80,11 @@ def make_winston(din, dout, crit_angle, width, height, n_points=512):
   return config
 
 
-def make_sensor(dout, sensor_curv=None, n_points=25):
+def make_sensor(
+    dout: float,
+    sensor_curv: Optional[float] = None,
+    n_points: int = 25,
+) -> Dict[str, Sequence[float]]:
   """Generate a sensing surface at the exit plane."""
   if sensor_curv is not None:
     x = np.linspace(-dout / 2, dout / 2, n_points)

--- a/run_2D.py
+++ b/run_2D.py
@@ -3,14 +3,22 @@ import numpy as np
 import matplotlib.pyplot as plt
 import mplhep as hep
 from tqdm import tqdm
+from typing import Dict, List, Optional, Sequence, Tuple
 
 import sys
 sys.path.append('python')
 from ConeProfile import *
 
-tol = 1e-7
+tol: float = 1e-7
 
-def findSegments(x0, y0, vx, vy, mx, my):
+def findSegments(
+    x0: float,
+    y0: float,
+    vx: float,
+    vy: float,
+    mx: np.ndarray,
+    my: np.ndarray,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
   dmx = mx[1:]-mx[:-1]
   dmy = my[1:]-my[:-1]
 
@@ -35,14 +43,21 @@ def findSegments(x0, y0, vx, vy, mx, my):
 
   return x[hit], y[hit], dmx[hit], dmy[hit]
 
-def getDist(x0, y0, vx, vy, x, y):
+def getDist(
+    x0: float,
+    y0: float,
+    vx: float,
+    vy: float,
+    x: np.ndarray,
+    y: np.ndarray,
+) -> np.ndarray:
   dx = x - x0
   dy = y - y0
   r = (vx*dx + vy*dy) / np.hypot(vx, vy)
 
   return r
 
-def reflect(vx, vy, dx, dy):
+def reflect(vx: float, vy: float, dx: float, dy: float) -> Tuple[float, float]:
   dr = np.hypot(dx, dy)
   dx, dy = dx/dr, dy/dr
   nx, ny = -dy, dx
@@ -57,7 +72,14 @@ def reflect(vx, vy, dx, dy):
 
   return ux, uy
 
-def propagate(x0, y0, angle, mirrors, sensor=None, n_bounces=20):
+def propagate(
+    x0: float,
+    y0: float,
+    angle: float,
+    mirrors: List[Dict[str, Sequence[float]]],
+    sensor: Optional[Dict[str, Sequence[float]]] = None,
+    n_bounces: int = 20,
+) -> Tuple[np.ndarray, np.ndarray, str]:
   rad = np.deg2rad(angle-90)
   vx, vy = np.cos(rad), np.sin(rad)
   xs, ys = [x0], [y0]


### PR DESCRIPTION
## Summary
- add explicit type hints to 2D ray tracing helpers
- annotate cone profile generation functions

## Testing
- `python -m py_compile run_2D.py python/ConeProfile.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcf74f5594832b80c59bc51bda06f9