### PR TITLE
Fix mirror segment check for 3D cone ray tracing

### DIFF
--- a/run_3Dcone.py
+++ b/run_3Dcone.py
@@ -57,7 +57,7 @@ def findSegments(x0: float, y0: float, z0: float,
   z = z0 + t * vz
   w = np.hypot(x,z)
 
-  hit = (t > tol) & ((y - mh[1:])*(y - mh[:-1]) < 0) & ((w - mw[:1])*(w - mw[:-1]) < 0)
+  hit = (t > tol) & ((y - mh[1:])*(y - mh[:-1]) < 0) & ((w - mw[1:])*(w - mw[:-1]) < 0)
 
   ny = -dmw
   nw = dmh


### PR DESCRIPTION
## Summary
- fix mirror intersection mask in `findSegments` so radial bounds use segment endpoints instead of the first point

## Testing
- `MPLBACKEND=Agg python run_3Dcone.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5767f8320832ba584fea7f05cebc7